### PR TITLE
Fix write raw

### DIFF
--- a/msr605.py
+++ b/msr605.py
@@ -170,6 +170,13 @@ class MSR605(serial.Serial):
         self._send_command('\x6F', chr(t1), chr(t2), chr(t3))
         self._expect(self.ESC_CHR + '\x30' + chr(t1) + chr(t2) + chr(t3))
 
+    def _reverse_bits(self, s):
+        nv = ''
+        value = bytearray(s)
+        for b in value:
+            nv += chr(int('{:08b}'.format(b)[::-1], 2))
+        return nv
+
     def write_raw(self, *tracks):
         assert len(tracks) == 3
         raw_data_block = self.ESC_CHR + '\x73'
@@ -178,7 +185,7 @@ class MSR605(serial.Serial):
                 self.ESC_CHR +\
                 chr(tn + 1) +\
                 chr(len(track)) +\
-                track
+                self._reverse_bits(track)
         raw_data_block += '\x3F' + self.FS_CHR
         self._send_command('\x6E', raw_data_block)
         self._read_status()


### PR DESCRIPTION
The MSR605 requires that the bits in each byte be reversed when writing a card. This change enables data read via read_raw to be written back with write_raw.

Additionally the serial connection will be flushed after each send command in order to ensure the reader receives  the command. (Else back to back send commands will clear the buffers resulting in previously issued commands not being sent. This is only of a concern for commands which do not immediately wait for a status code to be returned e.g. reset)
