### PR TITLE
Fix bug when setting BPI of track 1 and 2

### DIFF
--- a/msr605.py
+++ b/msr605.py
@@ -158,9 +158,9 @@ class MSR605(serial.Serial):
         self._read_status()
 
     def select_bpi(self, t1_density, t2_density, t3_density):
-        self._send_command('\x62', t1_density and '\xD2' or '\x4B')
+        self._send_command('\x62', t2_density and '\xD2' or '\x4B')
         self._read_status()
-        self._send_command('\x62', t2_density and '\xA1' or '\xA0')
+        self._send_command('\x62', t1_density and '\xA1' or '\xA0')
         self._read_status()
         self._send_command('\x62', t3_density and '\xC1' or '\xC0')
         self._read_status()


### PR DESCRIPTION
Per the Programmer’s Manual the BPI of track 1 and 2 were being set incorrectly.
![screen shot 2014-12-29 at 2 33 06 pm](https://cloud.githubusercontent.com/assets/828153/5572711/c18ac994-8f67-11e4-84d2-27720b1e662b.png)
